### PR TITLE
Update name validation rules

### DIFF
--- a/models/Tag.php
+++ b/models/Tag.php
@@ -65,8 +65,8 @@ class Tag extends ModelAbstract
      * @var array
      */
     public $rules = [
-        'name' => "required|unique:" . self::TABLE_NAME . "|min:3|regex:/^[a-z0-9\- ]+$/i",
-        'slug' => "required|unique:" . self::TABLE_NAME . "|min:3|regex:/^[a-z0-9\-]+$/i"
+        'name' => "required|unique:" . self::TABLE_NAME . "|min:2|regex:/^[a-z0-9\-\. ]+$/i",
+        'slug' => "required|unique:" . self::TABLE_NAME . "|min:2|regex:/^[a-z0-9\-]+$/i"
     ];
 
     /**


### PR DESCRIPTION
I have some problme with tags like "AI", "2D" and "2.5D"

Fixes # .

Changes proposed in this pull request:

tags name and slug can be 2 char length and name can contain "."

@GinoPane
