### PR TITLE
Fixes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Available properties:
 * **Display empty series** - whether to show series which don't have any posts assigned or not;
 * **Limit** - number of series to display, 0 retrieves all series;
 * **Series order** - how series list should be ordered;
-* **Series page** - CMS page which contains [`postsInSeries`](#posts-in-the-series) component and is used to display a single series content and posts.
+* **Series page** - CMS page which contains [`postsInSeries`](#posts-in-the-series) component and is used to display a single series content and posts;
+* **Fetch related posts** - if enabled, the component will fetch related posts, so they are properly available as `posts` property of the series item; it does an additional request, so decreases performance a little.
 
 ### Tag List
 
@@ -132,6 +133,7 @@ Available properties:
 * **Expose total count** - the component has `totalCount` property which would contain either overall amount of tags or
 amount of tags under "limit" only. For example you have 10 tags overall but you use a **limit** of 5. This will make component
 to display 5 tags only. With **Expose total count** enabled you could still get "10" in `totalCount`. And you'll get 5 otherwise;
+* **Fetch related posts** - if enabled, the component will fetch related posts, so they are properly available as `posts` property of the tag item; it does an additional request, so decreases performance a little;
 
 > Leave this as `false` if you do not require a whole total count, because it will give you more optimised result
 

--- a/components/SeriesList.php
+++ b/components/SeriesList.php
@@ -51,6 +51,13 @@ class SeriesList extends ComponentAbstract
     public $limit;
 
     /**
+     * Whether to query related posts or not
+     *
+     * @var string
+     */
+    private $fetchPosts;
+
+    /**
      * @return array
      */
     public function componentDetails()
@@ -72,6 +79,13 @@ class SeriesList extends ComponentAbstract
                 'description' =>    Plugin::LOCALIZATION_KEY . 'components.series_list.display_empty_description',
                 'type'        =>    'checkbox',
                 'default'     =>    false,
+                'showExternalParam' => false
+            ],
+            'fetchPosts' => [
+                'title'             => Plugin::LOCALIZATION_KEY . 'components.series_list.fetch_posts_title',
+                'description'       => Plugin::LOCALIZATION_KEY . 'components.series_list.fetch_posts_description',
+                'type'              => 'checkbox',
+                'default'           => false,
                 'showExternalParam' => false
             ],
             'limit' => [
@@ -130,7 +144,8 @@ class SeriesList extends ComponentAbstract
     {
         $this->seriesPage = $this->getProperty('seriesPage');
         $this->orderBy = $this->getProperty('orderBy');
-        $this->displayEmpty = $this->getProperty('displayEmpty');
+        $this->displayEmpty = (bool) $this->getProperty('displayEmpty');
+        $this->fetchPosts = (bool) $this->getProperty('fetchPosts');
         $this->limit = $this->getProperty('limit');
 
         $this->series = $this->listSeries();
@@ -146,9 +161,20 @@ class SeriesList extends ComponentAbstract
         $series = Series::listFrontend([
             'sort' => $this->orderBy,
             'displayEmpty' => $this->displayEmpty,
-            'limit' => $this->limit
+            'limit' => $this->limit,
+            'fetchPosts' => $this->fetchPosts
         ]);
 
+        $this->handleUrls($series);
+
+        return $series;
+    }
+
+    /**
+     * @param $series
+     */
+    private function handleUrls($series)
+    {
         $seriesComponent = $this->getComponent(SeriesPosts::NAME, $this->seriesPage);
 
         $this->setUrls(
@@ -159,7 +185,5 @@ class SeriesList extends ComponentAbstract
                 'series' => $this->urlProperty($seriesComponent, 'series')
             ]
         );
-
-        return $series;
     }
 }

--- a/components/TagList.php
+++ b/components/TagList.php
@@ -66,6 +66,13 @@ class TagList extends ComponentAbstract
     private $postSlug;
 
     /**
+     * Whether to query related posts or not
+     *
+     * @var string
+     */
+    private $fetchPosts;
+
+    /**
      * Limits the number of records to display
      *
      * @var int
@@ -145,6 +152,13 @@ class TagList extends ComponentAbstract
             'displayEmpty' => [
                 'title'             => Plugin::LOCALIZATION_KEY . 'components.tag_list.display_empty_title',
                 'description'       => Plugin::LOCALIZATION_KEY . 'components.tag_list.display_empty_description',
+                'type'              => 'checkbox',
+                'default'           => false,
+                'showExternalParam' => false
+            ],
+            'fetchPosts' => [
+                'title'             => Plugin::LOCALIZATION_KEY . 'components.tag_list.fetch_posts_title',
+                'description'       => Plugin::LOCALIZATION_KEY . 'components.tag_list.fetch_posts_description',
                 'type'              => 'checkbox',
                 'default'           => false,
                 'showExternalParam' => false
@@ -257,6 +271,7 @@ class TagList extends ComponentAbstract
 
         $this->orderBy = $this->getProperty('orderBy');
         $this->postSlug = $this->getProperty('postSlug');
+        $this->fetchPosts = (bool) $this->getProperty('fetchPosts');
         $this->displayEmpty = (bool) $this->getProperty('displayEmpty');
         $this->limit =  (int) $this->getProperty('limit');
         $this->exposeTotalCount =  (bool) $this->getProperty('exposeTotalCount');
@@ -274,7 +289,8 @@ class TagList extends ComponentAbstract
             'sort' => $this->orderBy,
             'displayEmpty' => $this->displayEmpty,
             'limit' => $this->limit,
-            'post' => $this->postSlug
+            'post' => $this->postSlug,
+            'fetchPosts' => $this->fetchPosts
         ]);
 
         $this->handleCount($tags);

--- a/components/serieslist/default.htm
+++ b/components/serieslist/default.htm
@@ -3,7 +3,7 @@
 {% if series|length %}
     <div class="list-group">
         {% for item in series %}
-            {% set postCount = item.posts|length %}
+            {% set postCount = item.posts_count %}
             <a href="{{ item.url }}" class="list-group-item">
                 {{ item.title }}
                 {% if postCount %}

--- a/components/taglist/default.htm
+++ b/components/taglist/default.htm
@@ -37,13 +37,13 @@
 {% if tags | length %}
     <div class="list-group" id="{{ tagSectionId }}">
         {% for item in tags %}
-        {% set postCount = item.posts|length %}
-        <a href="{{ item.url }}" class="list-group-item">
-            {{ item.name }}
-            {% if postCount %}
-                <span class="badge">{{ postCount }}</span>
-            {% endif %}
-        </a>
+            {% set postCount = item.posts_count %}
+            <a href="{{ item.url }}" class="list-group-item">
+                {{ item.name }}
+                {% if postCount %}
+                    <span class="badge">{{ postCount }}</span>
+                {% endif %}
+            </a>
         {% endfor %}
     </div>
 {% else %}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -155,6 +155,8 @@ return [
 
             'post_slug_title' => 'Post slug',
             'post_slug_description' => 'Get tags for the post specified by slug value from URL parameter',
+            'fetch_posts_title' => 'Fetch related posts',
+            'fetch_posts_description' => 'Fetches related posts so they are available as `posts` property of the tag item. Slows down performance',
 
             'no_tags_message' => 'No tags found',
             'all_tags_link' => 'Show all',
@@ -206,6 +208,9 @@ return [
 
             'series_slug_title' => 'Series slug parameter',
             'series_slug_description' => 'The setting must be equal to slug parameter being used for Series Page (e.g. /blog/series/:series will give you :series)',
+
+            'fetch_posts_title' => 'Fetch related posts',
+            'fetch_posts_description' => 'Fetches related posts so they are available as `posts` property of the series item. Slows down performance',
 
             'limit_title' => 'Limit',
             'limit_description' => 'Number of series to display, 0 retrieves all series',

--- a/models/ModelAbstract.php
+++ b/models/ModelAbstract.php
@@ -53,7 +53,7 @@ abstract class ModelAbstract extends Model
      */
     public function scopeListFrontend(Builder $query, array $options = [])
     {
-        $this->withRelation($query);
+        $this->withRelation($query, $options);
 
         $this->queryOrderBy($query, $options);
 
@@ -158,11 +158,22 @@ abstract class ModelAbstract extends Model
 
     /**
      * @param Builder $query
+     * @param array   $options
      *
      * @return void
      */
-    private function withRelation(Builder $query)
+    private function withRelation(Builder $query, array $options)
     {
+        if (!empty($options['fetchPosts'])) {
+            $query->with(
+                [
+                    'posts' => static function ($query) {
+                        $query->isPublished();
+                    }
+                ]
+            );
+        }
+
         $query->withCount(
             [
                 'posts' => static function ($query) {


### PR DESCRIPTION
Fixes #25.

Related posts were counted incorrectly in series list, though the same was fine in the tag list. 
Default templates were fixed to use `posts_count` property which is always correct.
A new option for fetching related posts was added, so related posts could be fetched when necessary.