### PR TITLE
Changed pivot table reference to correct one

### DIFF
--- a/updates/create_related_series_table.php
+++ b/updates/create_related_series_table.php
@@ -55,7 +55,7 @@ class CreateRelatedSeriesTable extends Migration
 
                     $table->integer('series_id')->unsigned();
                     $table->integer('related_series_id')->unsigned();
-                    $table->index(['series_id', 'related_series_id'], 'series_related');
+                    $table->index(['series_id', 'related_series_id'], 'related_series_index');
                     $table->foreign('series_id', 'Series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
                     $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
                 }

--- a/updates/create_related_series_table.php
+++ b/updates/create_related_series_table.php
@@ -55,7 +55,7 @@ class CreateRelatedSeriesTable extends Migration
 
                     $table->integer('series_id')->unsigned();
                     $table->integer('related_series_id')->unsigned();
-                    $table->index(['series_id', 'related_series_id'], 'series_related);
+                    $table->index(['series_id', 'related_series_id'], 'series_related');
                     $table->foreign('series_id', 'Series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
                     $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
                 }

--- a/updates/create_related_series_table.php
+++ b/updates/create_related_series_table.php
@@ -55,9 +55,9 @@ class CreateRelatedSeriesTable extends Migration
 
                     $table->integer('series_id')->unsigned();
                     $table->integer('related_series_id')->unsigned();
-                    $table->index(['series_id', 'related_series_id']);
+                    $table->index(['series_id', 'related_series_id'], 'series_related);
                     $table->foreign('series_id', 'Series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
-                    $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::RELATED_SERIES_TABLE_NAME)->onDelete('cascade');
+                    $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
                 }
             );
         }

--- a/updates/create_related_series_table.php
+++ b/updates/create_related_series_table.php
@@ -57,7 +57,7 @@ class CreateRelatedSeriesTable extends Migration
                     $table->integer('related_series_id')->unsigned();
                     $table->index(['series_id', 'related_series_id']);
                     $table->foreign('series_id', 'Series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
-                    $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::TABLE_NAME)->onDelete('cascade');
+                    $table->foreign('related_series_id', 'Related series reference')->references('id')->on(Series::RELATED_SERIES_TABLE_NAME)->onDelete('cascade');
                 }
             );
         }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

- Reference from the pivot table was wrong and I suggest to change the variable.

I noticed the issue because while I was migrating plugin tables, the following error occurred:
```
[Illuminate\Database\QueryException]
  SQLSTATE[42000]: Syntax error or access violation: 1059 Identifier name 'ginopane_blogtaxonomy_related_series_series_id_related_series_id_index'   
   is too long (SQL: alter table `ginopane_blogtaxonomy_related_series` add index `ginopane_blogtaxonomy_related_series_series_id_related_series_i   
  d_index`(`series_id`, `related_series_id`))
```

@GinoPane
