### PR TITLE
Include Tags Posts option in PostsInSeries Component

### DIFF
--- a/components/SeriesPosts.php
+++ b/components/SeriesPosts.php
@@ -47,6 +47,13 @@ class SeriesPosts extends PostListAbstract
                     'type'        => 'string',
                     'default'     => '{{ :series }}',
                 ],
+                'includeTagsPosts' => [
+                    'title'         => Plugin::LOCALIZATION_KEY . 'components.series_posts.include_tags_posts_title',
+                    'description'   => Plugin::LOCALIZATION_KEY . 'components.series_posts.include_tags_posts_description',
+                    'default'       => false,
+                    'type'          => 'checkbox',
+                    'showExternalParam' => false
+                ]
             ] + parent::defineProperties();
     }
 
@@ -68,8 +75,15 @@ class SeriesPosts extends PostListAbstract
     {
         $query = Post::whereHas('series', function ($query) {
             $query->whereTranslatable('slug', $this->series->slug);
-        })->isPublished();
-
+        });
+        if ($this->includeTagsPosts) {
+            $query->orWhereHas('tags', function ($query) {
+                $query->whereHas('series', function ($query) {
+                    $query->whereTranslatable('slug', $this->series->slug);
+                });
+            });
+        }
+        $query->isPublished();
         return $query;
     }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -166,7 +166,9 @@ return [
             'series_title' => 'Series slug',
             'series_description' => 'Look up the series using the supplied slug value from this URL parameter',
             'posts_in_series' => 'Posts included into the series',
-            'no_posts_message' => 'No posts in the series'
+            'no_posts_message' => 'No posts in the series',
+            'include_tags_posts_title' => 'Include tags posts',
+            'include_tags_posts_description' => 'Additionally include posts which belongs to the tags tagged with the current series'
         ],
         'tag_list' => [
             'name' => 'Tag List',


### PR DESCRIPTION
#77 

Changes proposed in this pull request:

- Include new funcionality 
- Enable the possibility to list posts related to a series and associated tags.


@GinoPane
